### PR TITLE
Update checkout.tpl

### DIFF
--- a/upload/custom/templates/DefaultRevamp/store/checkout.tpl
+++ b/upload/custom/templates/DefaultRevamp/store/checkout.tpl
@@ -112,7 +112,7 @@
             <div class="ui equal width grid">
                 <div class="column">
                     <div class="field">
-                        <div class="ui checkbox" style="display:inline;">
+                        <div class="ui checkbox">
                             <input type="checkbox" name="t_and_c" value="1" required> <label>{$AGREE_T_AND_C_PURCHASE}</label>
                         </div>
                     </div>


### PR DESCRIPTION
Add a fix to checkout.tpl to fix the placement of the T&C checkbox in Firefox (still renders the same in Chrome)

The issue is caused by fomatic-ui setting the top position to 0 with absolute positioning. When combined with a inline display rule, it causes Firefox to place the invisible checkbox above the styled checkbox.

This commit removes that style attribute. The style attribute is not useful either in this case, because the size of the div is small - so it can fit in-line with the "Purchase" button.